### PR TITLE
FEAT: Extend function support and return Personium exceptions

### DIFF
--- a/src/main/java/io/personium/engine/extension/httpclient/Ext_HttpClient.java
+++ b/src/main/java/io/personium/engine/extension/httpclient/Ext_HttpClient.java
@@ -44,6 +44,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
+import org.apache.http.util.TextUtils;
 import org.json.simple.JSONObject;
 import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.annotations.JSConstructor;
@@ -163,7 +164,7 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
      */
     @JSFunction
     public NativeObject postParam(String uri, NativeObject headers, String contentType, String params) {
-        return post(uri, headers, contentType, params, null, null);
+        return postX(uri, headers, contentType, params, null, null);
     }
     
     /**
@@ -176,7 +177,7 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
      */
     @JSFunction
     public NativeObject post(String uri, NativeObject headers, String contentType, String params) {
-        return post(uri, headers, contentType, params, null, null);
+        return postX(uri, headers, contentType, params, null, null);
     }
 
     /**
@@ -189,7 +190,7 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
      */
     @JSFunction
     public NativeObject putParam(String uri, NativeObject headers, String contentType, String params) {
-        return put(uri, headers, contentType, params, null, null);
+        return putX(uri, headers, contentType, params, null, null);
     }
     
     /**
@@ -202,7 +203,7 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
      */
     @JSFunction
     public NativeObject put(String uri, NativeObject headers, String contentType, String params) {
-        return put(uri, headers, contentType, params, null, null);
+        return putX(uri, headers, contentType, params, null, null);
     }
 
     /**
@@ -291,7 +292,7 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
 //    }
 
     /**
-     * Post.
+     * PostX.
      * @param uri String
      * @param headers NativeObject
      * @param contentType String
@@ -300,7 +301,7 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
      * @param fileName String
      * @return NativeObject
      */
-    private NativeObject post(String uri, NativeObject headers, String contentType,
+    private NativeObject postX(String uri, NativeObject headers, String contentType,
                               String params, PersoniumInputStream pis, String fileName) {
     	NativeObject result = null;
 
@@ -393,7 +394,7 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
     }
        
     /**
-     * put.
+     * putX.
      * @param uri String
      * @param headers NativeObject
      * @param contentType String
@@ -402,7 +403,7 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
      * @param fileName String
      * @return NativeObject
      */
-    private NativeObject put(String uri, NativeObject headers, String contentType,
+    private NativeObject putX(String uri, NativeObject headers, String contentType,
                               String params, PersoniumInputStream pis, String fileName) {
     	NativeObject result = null;
 
@@ -499,24 +500,26 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
         int port =  java.lang.Integer.getInteger("http.proxyPort");
         String id =  java.lang.System.getProperty("http.proxyUser");
         String pass =  java.lang.System.getProperty("http.proxyPassword");
-
-        if(pass != null || !pass.isEmpty()){
-            // use proxy with authentication
-            HttpHost proxy = new HttpHost(host, port);
-            CredentialsProvider credsProvider = new BasicCredentialsProvider();
-            credsProvider.setCredentials(
+        
+        if (!TextUtils.isEmpty(host)){
+            if(!TextUtils.isEmpty(pass)){
+                // use proxy with authentication
+                HttpHost proxy = new HttpHost(host, port);
+                CredentialsProvider credsProvider = new BasicCredentialsProvider();
+                credsProvider.setCredentials(
                     new AuthScope(proxy),
                     new UsernamePasswordCredentials(id, pass));
-            RequestConfig config = RequestConfig.custom()
+                RequestConfig config = RequestConfig.custom()
                     .setProxy(proxy)
                     .build();
-            CloseableHttpClient httpclient = HttpClients.custom()
+                CloseableHttpClient httpclient = HttpClients.custom()
                     .setDefaultCredentialsProvider(credsProvider)
                     .setDefaultRequestConfig(config)
                     .build();
-            return httpclient;
-        }else if(host != null || !host.isEmpty()){
-        	// use proxy
+                return httpclient;
+            }
+            
+            // use proxy
             HttpHost proxy = new HttpHost(host, port);
             RequestConfig config = RequestConfig.custom()
                     .setProxy(proxy)
@@ -525,10 +528,11 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
                     .setDefaultRequestConfig(config)
                     .build();
             return httpclient;
-        }else{
-            CloseableHttpClient httpclient = HttpClientBuilder.create().build();
-            return httpclient;
         }
+        
+        // default
+        CloseableHttpClient httpclient = HttpClientBuilder.create().build();
+        return httpclient;
     }
     
 }

--- a/src/main/java/io/personium/engine/extension/httpclient/Ext_HttpClient.java
+++ b/src/main/java/io/personium/engine/extension/httpclient/Ext_HttpClient.java
@@ -167,6 +167,19 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
     }
     
     /**
+     * post (String).
+     * @param uri String
+     * @param headers NativeObject
+     * @param contentType String
+     * @param params String
+     * @return NativeObject
+     */
+    @JSFunction
+    public NativeObject post(String uri, NativeObject headers, String contentType, String params) {
+        return post(uri, headers, contentType, params, null, null);
+    }
+
+    /**
      * putParam (String).
      * @param uri String
      * @param headers NativeObject
@@ -176,6 +189,19 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
      */
     @JSFunction
     public NativeObject putParam(String uri, NativeObject headers, String contentType, String params) {
+        return put(uri, headers, contentType, params, null, null);
+    }
+    
+    /**
+     * put (String).
+     * @param uri String
+     * @param headers NativeObject
+     * @param contentType String
+     * @param params String
+     * @return NativeObject
+     */
+    @JSFunction
+    public NativeObject put(String uri, NativeObject headers, String contentType, String params) {
         return put(uri, headers, contentType, params, null, null);
     }
 
@@ -211,9 +237,6 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
             // Retrieve the status.
             int status = res.getStatusLine().getStatusCode();
             log.debug("delete status:" + status);
-            if (status != HttpStatus.SC_NO_CONTENT) {
-                return null;
-            }
 
             // Retrieve the response headers.
             JSONObject res_headers = new JSONObject();
@@ -338,9 +361,6 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
 
             // Retrieve the status.
             int status = res.getStatusLine().getStatusCode();
-            if (status != HttpStatus.SC_OK) {
-                return null;
-            }
 
             // response headers
             JSONObject res_headers = new JSONObject();
@@ -443,9 +463,6 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
 
             // Retrieve the status.
             int status = res.getStatusLine().getStatusCode();
-            if (status != HttpStatus.SC_OK) {
-                return null;
-            }
 
             // response headers
             JSONObject res_headers = new JSONObject();

--- a/src/main/java/io/personium/engine/extension/httpclient/Ext_HttpClient.java
+++ b/src/main/java/io/personium/engine/extension/httpclient/Ext_HttpClient.java
@@ -497,42 +497,38 @@ public class Ext_HttpClient extends AbstractExtensionScriptableObject {
 
     private CloseableHttpClient createHTTPClient() {
         String host = java.lang.System.getProperty("http.proxyHost");
-        int port =  java.lang.Integer.getInteger("http.proxyPort");
+        Integer port =  java.lang.Integer.getInteger("http.proxyPort");
         String id =  java.lang.System.getProperty("http.proxyUser");
         String pass =  java.lang.System.getProperty("http.proxyPassword");
+        CloseableHttpClient httpclient;
         
-        if (!TextUtils.isEmpty(host)){
-            if(!TextUtils.isEmpty(pass)){
-                // use proxy with authentication
-                HttpHost proxy = new HttpHost(host, port);
-                CredentialsProvider credsProvider = new BasicCredentialsProvider();
-                credsProvider.setCredentials(
-                    new AuthScope(proxy),
-                    new UsernamePasswordCredentials(id, pass));
-                RequestConfig config = RequestConfig.custom()
-                    .setProxy(proxy)
-                    .build();
-                CloseableHttpClient httpclient = HttpClients.custom()
-                    .setDefaultCredentialsProvider(credsProvider)
-                    .setDefaultRequestConfig(config)
-                    .build();
-                return httpclient;
-            }
-            
-            // use proxy
+        if (TextUtils.isEmpty(host)){
+            // default
+            httpclient = HttpClientBuilder.create().build();
+        }else{
             HttpHost proxy = new HttpHost(host, port);
             RequestConfig config = RequestConfig.custom()
                     .setProxy(proxy)
                     .build();
-            CloseableHttpClient httpclient = HttpClients.custom()
+
+            if(TextUtils.isEmpty(pass)){
+                // use proxy without authentication
+                httpclient = HttpClients.custom()
                     .setDefaultRequestConfig(config)
                     .build();
-            return httpclient;
+            }else{
+                // use proxy with authentication
+                CredentialsProvider credsProvider = new BasicCredentialsProvider();
+                credsProvider.setCredentials(
+                    new AuthScope(proxy),
+                    new UsernamePasswordCredentials(id, pass));
+                httpclient = HttpClients.custom()
+                    .setDefaultCredentialsProvider(credsProvider)
+                    .setDefaultRequestConfig(config)
+                    .build();
+            }            
         }
-        
-        // default
-        CloseableHttpClient httpclient = HttpClientBuilder.create().build();
+         
         return httpclient;
     }
-    
 }


### PR DESCRIPTION
1. Add post & put functions
postParam and putParam will be deprecated.
2. Remove unnecessary status code check to return Personium response as is.